### PR TITLE
Adding `pyzmq-static` dependency instead of `pyzmq`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'coverage==3.5.1',
     ],
     install_requires=[
-        "pyzmq==2.2.0",
+        "pyzmq-static==2.1.11.2",
     ],
     tests_require=[
         "mock==0.8",


### PR DESCRIPTION
This fixes issue #22. All tests passes correctly on my computer.
